### PR TITLE
Improve nav styling and service form layout

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -8,15 +8,25 @@ body {
 .top-nav {
   background-color: #2563eb;
   color: #fff;
-  padding: 14px 24px;
+  padding: 18px 32px;
   display: flex;
   align-items: center;
   justify-content: space-between;
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-  animation: slideDown 0.3s ease forwards;
+}
+.nav-brand {
+  font-weight: 700;
+  font-size: 20px;
+  margin-right: 24px;
 }
 
+.nav-buttons {
+  display: flex;
+  gap: 12px;
+}
 .nav-buttons button {
+  display: flex;
+  align-items: center;
   background: transparent;
   border: none;
   color: #fff;
@@ -25,6 +35,12 @@ body {
   border-radius: 6px;
   cursor: pointer;
   transition: background-color 0.2s, transform 0.2s;
+}
+.nav-buttons button svg {
+  width: 18px;
+  height: 18px;
+  margin-right: 6px;
+  fill: currentColor;
 }
 
 .nav-buttons button:hover {
@@ -37,6 +53,40 @@ body {
   width: 24px;
   height: 24px;
   cursor: pointer;
+}
+
+.form-card {
+  background: #fff;
+  padding: 24px;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  max-width: 800px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.form-group label {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.primary-btn {
+  background-color: #3b82f6;
+  color: #fff;
+  border: none;
+  padding: 10px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+  margin-top: 16px;
 }
 
 .main-content {
@@ -70,7 +120,3 @@ body {
   to { opacity: 1; transform: translateY(0); }
 }
 
-@keyframes slideDown {
-  from { transform: translateY(-100%); }
-  to { transform: translateY(0); }
-}

--- a/templates/main-org.html
+++ b/templates/main-org.html
@@ -206,12 +206,16 @@
 </head>
 <body>
   <nav class="top-nav">
-    <div class="nav-buttons">
-      <button onclick="goToPage('main-org')">Dashboard</button>
-      <button onclick="goToPage('org-services')">Services</button>
-      <button onclick="goToPage('org-teams')">Teams</button>
-      <button onclick="goToPage('org-people')">People</button>
-      <button onclick="goToPage('org-messages')">Messages</button>
+    <div style="display:flex;align-items:center;">
+      <span class="nav-brand">ScheduleBuddy</span>
+      <div class="nav-buttons">
+        <button onclick="window.location.href='/user-organizations/'">My organizations</button>
+        <button onclick="goToPage('main-org')"><svg viewBox="0 0 24 24"><path d="M3 9.75L12 3l9 6.75V21a.75.75 0 01-.75.75H3.75A.75.75 0 013 21V9.75z"/><path d="M9 21V12h6v9"/></svg>Dashboard</button>
+        <button onclick="goToPage('org-services')"><svg viewBox="0 0 24 24"><path d="M3 4h18M3 8h18M5 4v16h14V4"/></svg>Services</button>
+        <button onclick="goToPage('org-teams')"><svg viewBox="0 0 24 24"><path d="M17 20v-2a3 3 0 00-3-3h-4a3 3 0 00-3 3v2"/><path d="M12 11a4 4 0 100-8 4 4 0 000 8z"/></svg>Teams</button>
+        <button onclick="goToPage('org-people')"><svg viewBox="0 0 24 24"><path d="M15 20v-2a4 4 0 00-4-4H9a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>People</button>
+        <button onclick="goToPage('org-messages')"><svg viewBox="0 0 24 24"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>Messages</button>
+      </div>
     </div>
 
     <div class="user-icon" id="user-icon-container">

--- a/templates/org-messages.html
+++ b/templates/org-messages.html
@@ -100,12 +100,16 @@
 </head>
 <body>
   <nav class="top-nav">
-    <div class="nav-buttons">
-      <button onclick="goToPage('main-org')">Dashboard</button>
-      <button onclick="goToPage('org-services')">Services</button>
-      <button onclick="goToPage('org-teams')">Teams</button>
-      <button onclick="goToPage('org-people')">People</button>
-      <button onclick="goToPage('org-messages')">Messages</button>
+    <div style="display:flex;align-items:center;">
+      <span class="nav-brand">ScheduleBuddy</span>
+      <div class="nav-buttons">
+        <button onclick="window.location.href='/user-organizations/'">My organizations</button>
+        <button onclick="goToPage('main-org')"><svg viewBox="0 0 24 24"><path d="M3 9.75L12 3l9 6.75V21a.75.75 0 01-.75.75H3.75A.75.75 0 013 21V9.75z"/><path d="M9 21V12h6v9"/></svg>Dashboard</button>
+        <button onclick="goToPage('org-services')"><svg viewBox="0 0 24 24"><path d="M3 4h18M3 8h18M5 4v16h14V4"/></svg>Services</button>
+        <button onclick="goToPage('org-teams')"><svg viewBox="0 0 24 24"><path d="M17 20v-2a3 3 0 00-3-3h-4a3 3 0 00-3 3v2"/><path d="M12 11a4 4 0 100-8 4 4 0 000 8z"/></svg>Teams</button>
+        <button onclick="goToPage('org-people')"><svg viewBox="0 0 24 24"><path d="M15 20v-2a4 4 0 00-4-4H9a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>People</button>
+        <button onclick="goToPage('org-messages')"><svg viewBox="0 0 24 24"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>Messages</button>
+      </div>
     </div>
 
     <div class="user-icon" id="user-icon-container">

--- a/templates/org-people.html
+++ b/templates/org-people.html
@@ -121,12 +121,16 @@
 </head>
 <body>
   <nav class="top-nav">
-    <div class="nav-buttons">
-      <button onclick="goToPage('main-org')">Dashboard</button>
-      <button onclick="goToPage('org-services')">Services</button>
-      <button onclick="goToPage('org-teams')">Teams</button>
-      <button onclick="goToPage('org-people')">People</button>
-      <button onclick="goToPage('org-messages')">Messages</button>
+    <div style="display:flex;align-items:center;">
+      <span class="nav-brand">ScheduleBuddy</span>
+      <div class="nav-buttons">
+        <button onclick="window.location.href='/user-organizations/'">My organizations</button>
+        <button onclick="goToPage('main-org')"><svg viewBox="0 0 24 24"><path d="M3 9.75L12 3l9 6.75V21a.75.75 0 01-.75.75H3.75A.75.75 0 013 21V9.75z"/><path d="M9 21V12h6v9"/></svg>Dashboard</button>
+        <button onclick="goToPage('org-services')"><svg viewBox="0 0 24 24"><path d="M3 4h18M3 8h18M5 4v16h14V4"/></svg>Services</button>
+        <button onclick="goToPage('org-teams')"><svg viewBox="0 0 24 24"><path d="M17 20v-2a3 3 0 00-3-3h-4a3 3 0 00-3 3v2"/><path d="M12 11a4 4 0 100-8 4 4 0 000 8z"/></svg>Teams</button>
+        <button onclick="goToPage('org-people')"><svg viewBox="0 0 24 24"><path d="M15 20v-2a4 4 0 00-4-4H9a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>People</button>
+        <button onclick="goToPage('org-messages')"><svg viewBox="0 0 24 24"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>Messages</button>
+      </div>
     </div>
 
     <div class="user-icon" id="user-icon-container">

--- a/templates/org-services.html
+++ b/templates/org-services.html
@@ -178,12 +178,16 @@
 </head>
 <body>
   <nav class="top-nav">
-    <div class="nav-buttons">
-      <button onclick="goToPage('main-org')">Dashboard</button>
-      <button onclick="goToPage('org-services')">Services</button>
-      <button onclick="goToPage('org-teams')">Teams</button>
-      <button onclick="goToPage('org-people')">People</button>
-      <button onclick="goToPage('org-messages')">Messages</button>
+    <div style="display:flex;align-items:center;">
+      <span class="nav-brand">ScheduleBuddy</span>
+      <div class="nav-buttons">
+        <button onclick="window.location.href='/user-organizations/'">My organizations</button>
+        <button onclick="goToPage('main-org')"><svg viewBox="0 0 24 24"><path d="M3 9.75L12 3l9 6.75V21a.75.75 0 01-.75.75H3.75A.75.75 0 013 21V9.75z"/><path d="M9 21V12h6v9"/></svg>Dashboard</button>
+        <button onclick="goToPage('org-services')"><svg viewBox="0 0 24 24"><path d="M3 4h18M3 8h18M5 4v16h14V4"/></svg>Services</button>
+        <button onclick="goToPage('org-teams')"><svg viewBox="0 0 24 24"><path d="M17 20v-2a3 3 0 00-3-3h-4a3 3 0 00-3 3v2"/><path d="M12 11a4 4 0 100-8 4 4 0 000 8z"/></svg>Teams</button>
+        <button onclick="goToPage('org-people')"><svg viewBox="0 0 24 24"><path d="M15 20v-2a4 4 0 00-4-4H9a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>People</button>
+        <button onclick="goToPage('org-messages')"><svg viewBox="0 0 24 24"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>Messages</button>
+      </div>
     </div>
 
     <div class="user-icon" id="user-icon-container">
@@ -210,58 +214,53 @@
     function showServiceForm() {
   mainContent.innerHTML = `
     <h2>Create New Service</h2>
-    <form id="service-form" style="max-width: 700px;">
-      <div style="margin-bottom: 16px;">
-        <label><strong>Service Name</strong></label><br/>
-        <input type="text" id="serviceName" required style="width: 100%; padding: 8px;" />
-      </div>
-
-      <div style="margin-bottom: 16px;">
-        <label><strong>Start Date & Time</strong></label><br/>
-        <input type="datetime-local" id="startDateTime" required style="width: 100%; padding: 8px;" />
-      </div>
-
-      <div style="margin-bottom: 16px;">
-        <label><strong>End Date & Time</strong></label><br/>
-        <input type="datetime-local" id="endDateTime" required style="width: 100%; padding: 8px;" />
-      </div>
-
-      <div style="margin-bottom: 16px;">
-        <label><strong>Location</strong> (Optional)</label><br/>
-        <input type="text" id="location" style="width: 100%; padding: 8px;" />
-      </div>
-
-      <div style="margin-bottom: 16px;">
-        <label><strong>Assign Teams</strong></label>
-        <div id="teams-list" style="margin-top: 8px;"></div>
-      </div>
-
-      <div style="margin-bottom: 16px;">
-        <label><input type="checkbox" id="isRecurring" onchange="toggleRecurrence()" /> This service recurs</label>
-      </div>
-
-      <div id="recurrence-options" style="display: none; border: 1px solid #ccc; padding: 12px; border-radius: 6px;">
-        <label><strong>Recurrence Pattern</strong></label><br/>
-        <select id="recurrencePattern" style="margin-bottom: 8px;">
-          <option value="daily">Daily</option>
-          <option value="weekly" selected>Weekly</option>
-          <option value="monthly">Monthly</option>
-        </select><br/>
-        <label>Repeat every <input type="number" id="repeatInterval" value="1" style="width: 60px;" /> week(s) on:</label><br/>
-        <div style="margin: 6px 0;">
-          <label><input type="checkbox" value="0" /> Sunday</label>
-          <label><input type="checkbox" value="1" /> Monday</label>
-          <label><input type="checkbox" value="2" /> Tuesday</label>
-          <label><input type="checkbox" value="3" /> Wednesday</label>
-          <label><input type="checkbox" value="4" /> Thursday</label>
-          <label><input type="checkbox" value="5" /> Friday</label>
-          <label><input type="checkbox" value="6" /> Saturday</label>
+    <form id="service-form" class="form-card">
+      <div class="form-grid">
+        <div class="form-group full-width">
+          <label>Service Name</label>
+          <input type="text" id="serviceName" required />
         </div>
-        <label>End After <input type="number" id="endOccurrences" value="10" style="width: 60px;" /> occurrences (Max 16 weeks)</label>
+        <div class="form-group">
+          <label>Start Date & Time</label>
+          <input type="datetime-local" id="startDateTime" required />
+        </div>
+        <div class="form-group">
+          <label>End Date & Time</label>
+          <input type="datetime-local" id="endDateTime" required />
+        </div>
+        <div class="form-group full-width">
+          <label>Location (Optional)</label>
+          <input type="text" id="location" />
+        </div>
+        <div class="form-group full-width">
+          <label>Assign Teams</label>
+          <div id="teams-list" style="margin-top:8px;"></div>
+        </div>
+        <div class="form-group full-width">
+          <label><input type="checkbox" id="isRecurring" onchange="toggleRecurrence()" /> This service recurs</label>
+        </div>
+        <div id="recurrence-options" class="form-group full-width" style="display:none; border:1px solid #ccc; padding:12px; border-radius:6px;">
+          <label>Recurrence Pattern</label>
+          <select id="recurrencePattern" style="margin-bottom:8px;">
+            <option value="daily">Daily</option>
+            <option value="weekly" selected>Weekly</option>
+            <option value="monthly">Monthly</option>
+          </select>
+          <label>Repeat every <input type="number" id="repeatInterval" value="1" style="width:60px;" /> week(s) on:</label>
+          <div style="margin:6px 0;">
+            <label><input type="checkbox" value="0" /> Sunday</label>
+            <label><input type="checkbox" value="1" /> Monday</label>
+            <label><input type="checkbox" value="2" /> Tuesday</label>
+            <label><input type="checkbox" value="3" /> Wednesday</label>
+            <label><input type="checkbox" value="4" /> Thursday</label>
+            <label><input type="checkbox" value="5" /> Friday</label>
+            <label><input type="checkbox" value="6" /> Saturday</label>
+          </div>
+          <label>End After <input type="number" id="endOccurrences" value="10" style="width:60px;" /> occurrences (Max 16 weeks)</label>
+        </div>
       </div>
-
-      <button type="submit" style="margin-top: 16px; padding: 10px 16px; background-color: #3b82f6; color: white; border: none; border-radius: 6px; cursor: pointer;">Create Service</button>
-      <p id="service-message" style="margin-top: 12px;"></p>
+      <button type="submit" class="primary-btn">Create Service</button>
+      <p id="service-message" style="margin-top:12px;"></p>
     </form>
   `;
   

--- a/templates/org-teams.html
+++ b/templates/org-teams.html
@@ -122,12 +122,16 @@
 </head>
 <body>
   <nav class="top-nav">
-    <div class="nav-buttons">
-      <button onclick="goToPage('main-org')">Dashboard</button>
-      <button onclick="goToPage('org-services')">Services</button>
-      <button onclick="goToPage('org-teams')">Teams</button>
-      <button onclick="goToPage('org-people')">People</button>
-      <button onclick="goToPage('org-messages')">Messages</button>
+    <div style="display:flex;align-items:center;">
+      <span class="nav-brand">ScheduleBuddy</span>
+      <div class="nav-buttons">
+        <button onclick="window.location.href='/user-organizations/'">My organizations</button>
+        <button onclick="goToPage('main-org')"><svg viewBox="0 0 24 24"><path d="M3 9.75L12 3l9 6.75V21a.75.75 0 01-.75.75H3.75A.75.75 0 013 21V9.75z"/><path d="M9 21V12h6v9"/></svg>Dashboard</button>
+        <button onclick="goToPage('org-services')"><svg viewBox="0 0 24 24"><path d="M3 4h18M3 8h18M5 4v16h14V4"/></svg>Services</button>
+        <button onclick="goToPage('org-teams')"><svg viewBox="0 0 24 24"><path d="M17 20v-2a3 3 0 00-3-3h-4a3 3 0 00-3 3v2"/><path d="M12 11a4 4 0 100-8 4 4 0 000 8z"/></svg>Teams</button>
+        <button onclick="goToPage('org-people')"><svg viewBox="0 0 24 24"><path d="M15 20v-2a4 4 0 00-4-4H9a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>People</button>
+        <button onclick="goToPage('org-messages')"><svg viewBox="0 0 24 24"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>Messages</button>
+      </div>
     </div>
 
     <div class="user-icon" id="user-icon-container">
@@ -270,7 +274,7 @@ async function initPage() {
 function showTeamForm(existingTeam = null) {
   mainContent.innerHTML = `
     <h2>Create New Team</h2>
-    <form id="team-form" style="max-width: 700px;">
+    <form id="team-form" class="form-card">
       <div style="margin-bottom: 20px;">
         <label><strong>Team Name</strong></label><br/>
         <input type="text" id="teamName" required style="width: 100%; padding: 8px;" />

--- a/templates/user-organizations.html
+++ b/templates/user-organizations.html
@@ -100,9 +100,12 @@
 </head>
 <body>
   <nav class="top-nav">
-    <div class="nav-buttons">
-      <button onclick="showJoinOrgPopup()">Join Org</button>
-      <button onclick="showStartOrgForm()">Start Org</button>
+    <div style="display:flex;align-items:center;">
+      <span class="nav-brand">ScheduleBuddy</span>
+      <div class="nav-buttons">
+        <button onclick="showJoinOrgPopup()">Join Org</button>
+        <button onclick="showStartOrgForm()">Start Org</button>
+      </div>
     </div>
 
     <div class="user-icon" id="user-icon-container">


### PR DESCRIPTION
## Summary
- enlarge top navigation and add company branding
- update nav buttons with icons and add "My organizations" back button
- modernize the service creation form using grid layout
- apply updated nav across all templates
- style forms with new reusable classes

## Testing
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_684135e056748324a77f005ae0b4b956