### PR TITLE
UI tweaks for login & orgs

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -49,6 +49,11 @@ body {
   background: #e5e7eb;
 }
 
+.nav-links button.active {
+  background: var(--brand-color);
+  color: #fff;
+}
+
 .nav-links .back-btn {
   background: var(--brand-color);
   color: #fff;
@@ -127,6 +132,17 @@ body {
 
 .secondary-btn:hover {
   background: #e5e7eb;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: #e5e7eb;
+  border-radius: 12px;
+  padding: 2px 8px;
+  font-size: 12px;
+  margin-left: 8px;
 }
 
 @media (max-width: 600px) {

--- a/static/styles.css
+++ b/static/styles.css
@@ -114,6 +114,21 @@ body {
   fill: var(--brand-color);
 }
 
+.secondary-btn {
+  background: #fff;
+  border: 1px solid var(--brand-color);
+  color: var(--brand-color);
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.secondary-btn:hover {
+  background: #e5e7eb;
+}
+
 @media (max-width: 600px) {
   .navbar {
     padding: 16px;

--- a/templates/login.html
+++ b/templates/login.html
@@ -5,6 +5,14 @@
   <title>Login</title>
   <link rel="stylesheet" href="/static/styles.css" />
   <style>
+    .brand-top {
+      text-align: center;
+      font-size: 32px;
+      font-weight: 600;
+      color: var(--brand-color);
+      margin-top: 40px;
+      margin-bottom: 20px;
+    }
     body {
       background-color: #f4f6f8;
       margin: 0;
@@ -81,9 +89,23 @@
     .submit-btn:hover {
       background-color: var(--brand-hover);
     }
+    .secondary-btn {
+      background: #fff;
+      border: 1px solid var(--brand-color);
+      color: var(--brand-color);
+      padding: 8px 12px;
+      border-radius: 8px;
+      cursor: pointer;
+      font-weight: 600;
+      transition: background-color 0.2s;
+    }
+    .secondary-btn:hover {
+      background: #e5e7eb;
+    }
   </style>
 </head>
 <body>
+  <div class="brand-top">ScheduleBuddy</div>
   <div class="login-container">
     <div class="login-form">
       <h2>Login</h2>
@@ -108,10 +130,9 @@
         {# Show these only when show_email_controls=True, with an inline style override #}
         {% if show_email_controls %}
           <div id="email-controls"
-               class="small-buttons"
                style="display:flex; justify-content:flex-end; gap:12px; margin-top:6px;">
-            <button type="submit" name="stage" value="request_otp">Edit Email</button>
-            <button type="submit" name="stage" value="request_otp">Resend OTP</button>
+            <button type="button" class="secondary-btn" onclick="submitStage('request_otp')">Edit Email</button>
+            <button type="button" class="secondary-btn" onclick="submitStage('request_otp')">Resend OTP</button>
           </div>
         {% endif %}
 
@@ -152,5 +173,12 @@
       </form>
     </div>
   </div>
+  <script>
+    function submitStage(stage) {
+      const form = document.querySelector('.login-form form');
+      form.querySelector('input[name="stage"]').value = stage;
+      form.submit();
+    }
+  </script>
 </body>
 </html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -10,7 +10,6 @@
       font-size: 32px;
       font-weight: 600;
       color: var(--brand-color);
-      margin-top: 40px;
       margin-bottom: 20px;
     }
     body {
@@ -105,8 +104,8 @@
   </style>
 </head>
 <body>
-  <div class="brand-top">ScheduleBuddy</div>
   <div class="login-container">
+    <div class="brand-top">ScheduleBuddy</div>
     <div class="login-form">
       <h2>Login</h2>
 

--- a/templates/main-org.html
+++ b/templates/main-org.html
@@ -66,27 +66,6 @@
   visibility: visible;
   opacity: 1;
 }
-       #floating-add-button {
-      position: fixed;
-      bottom: 24px;
-      right: 24px;
-      width: 56px;
-      height: 56px;
-      border-radius: 50%;
-      background-color: var(--brand-color);
-      color: white;
-      font-size: 32px;
-      line-height: 0;
-      border: none;
-      box-shadow: 0 4px 8px rgba(0,0,0,0.2);
-      cursor: pointer;
-      transition: background-color 0.2s ease;
-      z-index: 1000;
-    }
-    
-    #floating-add-button:hover {
-      background-color: var(--brand-hover);
-}
     #team-scheduler-button {
       position: fixed;
       bottom: 24px;
@@ -148,11 +127,11 @@
   <nav class="navbar">
     <div class="brand" onclick="window.location.href='/user-organizations'">ScheduleBuddy</div>
     <div class="nav-links">
-      <button onclick="goToPage('main-org')">Dashboard</button>
-      <button onclick="goToPage('org-services')">Services</button>
-      <button onclick="goToPage('org-teams')">Teams</button>
-      <button onclick="goToPage('org-people')">People</button>
-      <button onclick="goToPage('org-messages')">Messages</button>
+      <button id="nav-dashboard" onclick="goToPage('main-org')">Dashboard</button>
+      <button id="nav-services" onclick="goToPage('org-services')">Services</button>
+      <button id="nav-teams" onclick="goToPage('org-teams')">Teams</button>
+      <button id="nav-people" onclick="goToPage('org-people')">People</button>
+      <button id="nav-messages" onclick="goToPage('org-messages')">Messages</button>
       <button class="back-btn" onclick="window.location.href='/user-organizations'">My organizations</button>
       <div class="user-icon" id="user-icon-container" style="position: relative;">
         <svg id="user-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
@@ -166,6 +145,10 @@
       </div>
     </div>
   </nav>
+
+  <div class="page-actions" id="page-actions" style="padding:20px 40px;">
+    <button class="secondary-btn" onclick="showCalendar()">Schedule your Availability</button>
+  </div>
 
   <div class="main-content" id="main-content">
     <p class="message">Loading organization...</p>
@@ -186,6 +169,11 @@
 const userEmail = localStorage.getItem("user_email");
 const firstName = localStorage.getItem("user_first_name") || "";
 const lastName = localStorage.getItem("user_last_name") || "";
+
+function setActiveNav(page) {
+  const btn = document.getElementById('nav-' + page);
+  if (btn) btn.classList.add('active');
+}
 
 const userIcon = document.getElementById('user-icon');
 const userPopup = document.getElementById('user-popup');
@@ -298,7 +286,10 @@ async function loadUserDashboard() {
   }
 }
 
-window.addEventListener("DOMContentLoaded", loadUserDashboard);
+window.addEventListener("DOMContentLoaded", () => {
+  setActiveNav('dashboard');
+  loadUserDashboard();
+});
 
 let calendarInstance = null;
 const selectedDates = new Set();
@@ -428,13 +419,5 @@ function removeInabilityDateFromDatabase(dateStr) {
   });
 }
 </script>
-<div class="tooltip">
-  <button onclick="showCalendar()" id="floating-add-button" style="display: block;">
-    <svg class="icon" viewBox="0 0 24 24">
-      <path d="M5 3a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2H5zm0 4h14v12H5V7zm2-4h2v2H7V3zm8 0h2v2h-2V3z"/>
-    </svg>
-  </button>
-  <span class="tooltiptext">Schedule Your Availability</span>
-</div>
 </body>
 </html>

--- a/templates/org-people.html
+++ b/templates/org-people.html
@@ -39,6 +39,9 @@
 
     .main-content {
       flex: 1;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 20px;
       padding: 40px;
     }
 
@@ -72,38 +75,17 @@
       color: #555;
       margin-top: 4px;
     }
-           #floating-add-button {
-      position: fixed;
-      bottom: 24px;
-      right: 24px;
-      width: 56px;
-      height: 56px;
-      border-radius: 50%;
-      background-color: var(--brand-color);
-      color: white;
-      font-size: 32px;
-      line-height: 0;
-      border: none;
-      box-shadow: 0 4px 8px rgba(0,0,0,0.2);
-      cursor: pointer;
-      transition: background-color 0.2s ease;
-      z-index: 1000;
-    }
-    
-    #floating-add-button:hover {
-      background-color: var(--brand-hover);
-}
   </style>
 </head>
 <body>
   <nav class="navbar">
     <div class="brand" onclick="window.location.href='/user-organizations'">ScheduleBuddy</div>
     <div class="nav-links">
-      <button onclick="goToPage('main-org')">Dashboard</button>
-      <button onclick="goToPage('org-services')">Services</button>
-      <button onclick="goToPage('org-teams')">Teams</button>
-      <button onclick="goToPage('org-people')">People</button>
-      <button onclick="goToPage('org-messages')">Messages</button>
+      <button id="nav-dashboard" onclick="goToPage('main-org')">Dashboard</button>
+      <button id="nav-services" onclick="goToPage('org-services')">Services</button>
+      <button id="nav-teams" onclick="goToPage('org-teams')">Teams</button>
+      <button id="nav-people" onclick="goToPage('org-people')">People</button>
+      <button id="nav-messages" onclick="goToPage('org-messages')">Messages</button>
       <button class="back-btn" onclick="window.location.href='/user-organizations'">My organizations</button>
       <div class="user-icon" id="user-icon-container" style="position: relative;">
         <svg id="user-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
@@ -118,6 +100,10 @@
     </div>
   </nav>
 
+  <div class="page-actions" id="page-actions" style="padding:20px 40px; display:flex; gap:12px;">
+    <button class="secondary-btn" onclick="showImportModal()">Add People</button>
+  </div>
+
   <div class="main-content" id="main-content">
     <p class="message">Loading people...</p>
   </div>
@@ -130,6 +116,11 @@
 const userEmail = localStorage.getItem("user_email");
 const firstName = localStorage.getItem("user_first_name") || "";
 const lastName = localStorage.getItem("user_last_name") || "";
+
+function setActiveNav(page) {
+  const btn = document.getElementById('nav-' + page);
+  if (btn) btn.classList.add('active');
+}
 
 const userIcon = document.getElementById('user-icon');
 const userPopup = document.getElementById('user-popup');
@@ -570,6 +561,7 @@ async function initiateOwnershipTransfer(newOwnerEmail, newOwnerFirst, newOwnerL
   }
 }
 
+setActiveNav('people');
 initPage();
 
   
@@ -753,9 +745,6 @@ document.addEventListener("DOMContentLoaded", function () {
 });
 </script>
   
-<div class="tooltip">
-  <button onclick="showImportModal()" id="floating-add-button">+</button>
-</div>
 <div id="import-modal" style="display: none; position: fixed; top: 0; left: 0; width: 100vw; height: 100vh; background: rgba(0,0,0,0.4); z-index: 2000; justify-content: center; align-items: center;">
   <div style="background: white; padding: 24px; border-radius: 8px; width: 90%; max-width: 800px; position: relative;">
     <button onclick="closeImportModal()" style="position: absolute; top: 10px; right: 10px; font-size: 18px;">❌</button>

--- a/templates/org-services.html
+++ b/templates/org-services.html
@@ -38,6 +38,9 @@
 
     .main-content {
       flex: 1;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 20px;
       padding: 40px;
     }
 
@@ -70,48 +73,6 @@
       font-size: 14px;
       color: #555;
       margin-top: 4px;
-    }
-       #floating-add-button {
-      position: fixed;
-      bottom: 24px;
-      right: 24px;
-      width: 56px;
-      height: 56px;
-      border-radius: 50%;
-      background-color: var(--brand-color);
-      color: white;
-      font-size: 32px;
-      line-height: 0;
-      border: none;
-      box-shadow: 0 4px 8px rgba(0,0,0,0.2);
-      cursor: pointer;
-      transition: background-color 0.2s ease;
-      z-index: 1000;
-    }
-    
-    #floating-add-button:hover {
-      background-color: var(--brand-hover);
-}
-    #team-scheduler-button {
-      position: fixed;
-      bottom: 24px;
-      right: 92px; 
-      width: 56px;
-      height: 56px;
-      border-radius: 50%;
-      background-color: #10b981;
-      border: none;
-      box-shadow: 0 4px 8px rgba(0,0,0,0.2);
-      cursor: pointer;
-      transition: background-color 0.2s ease;
-      z-index: 1000;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-    
-    #team-scheduler-button:hover {
-      background-color: #059669;
     }
     .tooltip {
   position: relative;
@@ -155,11 +116,11 @@
   <nav class="navbar">
     <div class="brand" onclick="window.location.href='/user-organizations'">ScheduleBuddy</div>
     <div class="nav-links">
-      <button onclick="goToPage('main-org')">Dashboard</button>
-      <button onclick="goToPage('org-services')">Services</button>
-      <button onclick="goToPage('org-teams')">Teams</button>
-      <button onclick="goToPage('org-people')">People</button>
-      <button onclick="goToPage('org-messages')">Messages</button>
+      <button id="nav-dashboard" onclick="goToPage('main-org')">Dashboard</button>
+      <button id="nav-services" onclick="goToPage('org-services')">Services</button>
+      <button id="nav-teams" onclick="goToPage('org-teams')">Teams</button>
+      <button id="nav-people" onclick="goToPage('org-people')">People</button>
+      <button id="nav-messages" onclick="goToPage('org-messages')">Messages</button>
       <button class="back-btn" onclick="window.location.href='/user-organizations'">My organizations</button>
       <div class="user-icon" id="user-icon-container" style="position: relative;">
         <svg id="user-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
@@ -174,6 +135,12 @@
     </div>
   </nav>
 
+  <div class="page-actions" id="page-actions" style="padding:20px 40px; display:flex; gap:12px;">
+    <button class="secondary-btn" onclick="showServiceForm()">Create Service</button>
+    <button class="secondary-btn" onclick="renderTeamScheduler()">Schedule Team Members</button>
+    <button class="secondary-btn" onclick="renderCalendarView()">Export Schedule</button>
+  </div>
+
   <div class="main-content" id="main-content">
     <p class="message">Loading services...</p>
   </div>
@@ -183,6 +150,7 @@
 <script>
     let allTeams = [];
   function showServiceForm() {
+  mainContent.style.display = 'block';
   mainContent.innerHTML = `
     <h2>Create New Service</h2>
     <form id="service-form" class="form-grid" style="max-width: 800px;">
@@ -255,6 +223,11 @@ const userEmail = localStorage.getItem("user_email");
 const firstName = localStorage.getItem("user_first_name") || "";
 const lastName = localStorage.getItem("user_last_name") || "";
 
+function setActiveNav(page) {
+  const btn = document.getElementById('nav-' + page);
+  if (btn) btn.classList.add('active');
+}
+
 const userIcon = document.getElementById('user-icon');
 const userPopup = document.getElementById('user-popup');
 const popupName = document.getElementById('popup-name');
@@ -296,8 +269,10 @@ async function loadServices({ isOwner, isOrgAdmin }) {
     return;
   }
 
+  mainContent.style.display = 'grid';
+
   try {
-    const res = await fetch(`https://api.worshipbuddy.org/schedulebuddy/organizations/${orgId}/services`);
+  const res = await fetch(`https://api.worshipbuddy.org/schedulebuddy/organizations/${orgId}/services`);
     const services = await res.json();
     const now = new Date();
     const upcomingServices = services.filter(service => new Date(service.end_datetime) > now);
@@ -316,16 +291,23 @@ async function loadServices({ isOwner, isOrgAdmin }) {
       const card = document.createElement('div');
       card.className = 'org-card';
 
-      const startDate = new Date(service.start_datetime).toLocaleString();
-      const endDate = new Date(service.end_datetime).toLocaleString();
+      const start = new Date(service.start_datetime);
+      const end = new Date(service.end_datetime);
+      const dateStr = start.toLocaleDateString();
+      const timeStr = `${start.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'})} - ${end.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'})}`;
       const teamNames = service.teams?.map(t => t.team_name).join(', ') || 'No teams assigned';
 
+      const recurring = service.recurrence_pattern || service.is_recurring;
+
       card.innerHTML = `
-  <div class="org-name">${service.service_name}</div>
-  <div class="org-id"><svg class="icon" viewBox="0 0 24 24"><path d="M12 2C8.1 2 5 5.1 5 9c0 5.2 7 13 7 13s7-7.8 7-13c0-3.9-3.1-7-7-7zm0 9.5A2.5 2.5 0 1 1 12 6a2.5 2.5 0 0 1 0 5.5z"/></svg> ${service.location}</div>
-  <div class="org-id"><svg class="icon" viewBox="0 0 24 24"><path d="M12 6v6l4 2" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/></svg> ${startDate} → ${endDate}</div>
-  ${isOwner || isOrgAdmin ? `<div class="org-id">Teams: ${teamNames}</div>` : ""}
-`;
+        <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:6px;">
+          <span class="org-name">${service.service_name}</span>
+          ${recurring ? `<span class="pill"><svg class="icon" viewBox='0 0 24 24'><path d='M12 4v1a7 7 0 0 1 0 14v1a8 8 0 0 0 0-16zM11 5a7 7 0 0 0 0 14v1a8 8 0 0 1 0-16v1z'/></svg> Recurring</span>` : ''}
+        </div>
+        <div class="org-id"><svg class="icon" viewBox="0 0 24 24"><path d="M19 4h-1V2h-2v2H8V2H6v2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 16H5V9h14v11z"/></svg> ${dateStr}</div>
+        <div class="org-id"><svg class="icon" viewBox="0 0 24 24"><path d="M12 8v4l3 3" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/></svg> ${timeStr}</div>
+        <div class="org-id"><svg class="icon" viewBox="0 0 24 24"><path d="M12 12c2.7 0 5-2.3 5-5s-2.3-5-5-5-5 2.3-5 5 2.3 5 5 5zm0 2c-3.3 0-10 1.7-10 5v3h20v-3c0-3.3-6.7-5-10-5z"/></svg> Team: ${teamNames}</div>
+      `;
       const userTeams = userTeamPermissions.map(tp => tp.team_name);
     const userRoles = userTeamPermissions.reduce((acc, tp) => {
       acc[tp.team_name] = tp.permissions;
@@ -374,9 +356,10 @@ async function initPage() {
     const showScheduleService = isOwner || isOrgAdmin;
     const showTeamScheduler = isOwner || isOrgAdmin || userTeamPermissions.some(tp => tp.permissions.includes("Scheduler"));
 
-    document.getElementById("floating-add-button").style.display = showScheduleService ? "block" : "none";
-    document.getElementById("team-scheduler-button").style.display = showTeamScheduler ? "flex" : "none";
-    document.getElementById("calendar-view-button").style.display = showScheduleService ? "flex" : "none";
+    const actions = document.getElementById('page-actions').querySelectorAll('button');
+    actions[0].style.display = showScheduleService ? 'inline-block' : 'none';
+    actions[1].style.display = showTeamScheduler ? 'inline-block' : 'none';
+    actions[2].style.display = showScheduleService ? 'inline-block' : 'none';
 
     loadServices({ isOwner, isOrgAdmin });
   } catch (err) {
@@ -385,6 +368,7 @@ async function initPage() {
   }
 }
 
+setActiveNav('services');
 initPage();
 
 function toggleRecurrence() {
@@ -1266,30 +1250,5 @@ function exportCalendarToExcel() {
 </script>
 
 
-<div class="tooltip">
-  <button onclick="showServiceForm()" id="floating-add-button" style="display: none;">
-    <svg class="icon" viewBox="0 0 24 24">
-      <path d="M12 5v14m7-7H5" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/>
-    </svg>
-  </button>
-  <span class="tooltiptext">Schedule Service</span>
-</div>
-
-<div class="tooltip">
-  <button onclick="renderTeamScheduler()" id="team-scheduler-button" style="display: none;">
-    <svg class="icon" viewBox="0 0 24 24">
-      <path d="M12 12a5 5 0 1 0 0-10 5 5 0 0 0 0 10zm0 2c-3.3 0-10 1.7-10 5v3h20v-3c0-3.3-6.7-5-10-5z"/>
-    </svg>
-  </button>
-  <span class="tooltiptext">Schedule Team Members</span>
-</div>
-<div class="tooltip">
-  <button onclick="renderCalendarView()" id="calendar-view-button" style="display: none; position: fixed; bottom: 24px; right: 160px; width: 56px; height: 56px; border-radius: 50%; background-color: #f59e0b; border: none; box-shadow: 0 4px 8px rgba(0,0,0,0.2); cursor: pointer; display: flex; align-items: center; justify-content: center;">
-    <svg class="icon" viewBox="0 0 24 24" style="fill:#fff;">
-      <path d="M5 3a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2H5zm0 4h14v12H5V7zm2-4h2v2H7V3zm8 0h2v2h-2V3z"/>
-    </svg>
-  </button>
-  <span class="tooltiptext">Export Schedule Calendar</span>
-</div>
 </body>
 </html>

--- a/templates/org-teams.html
+++ b/templates/org-teams.html
@@ -39,6 +39,9 @@
 
     .main-content {
       flex: 1;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 20px;
       padding: 40px;
     }
 
@@ -73,38 +76,17 @@
       margin-top: 4px;
     }
     
-    #floating-add-button {
-      position: fixed;
-      bottom: 24px;
-      right: 24px;
-      width: 56px;
-      height: 56px;
-      border-radius: 50%;
-      background-color: var(--brand-color);
-      color: white;
-      font-size: 32px;
-      line-height: 0;
-      border: none;
-      box-shadow: 0 4px 8px rgba(0,0,0,0.2);
-      cursor: pointer;
-      transition: background-color 0.2s ease;
-      z-index: 1000;
-    }
-    
-    #floating-add-button:hover {
-      background-color: var(--brand-hover);
-}
   </style>
 </head>
 <body>
   <nav class="navbar">
     <div class="brand" onclick="window.location.href='/user-organizations'">ScheduleBuddy</div>
     <div class="nav-links">
-      <button onclick="goToPage('main-org')">Dashboard</button>
-      <button onclick="goToPage('org-services')">Services</button>
-      <button onclick="goToPage('org-teams')">Teams</button>
-      <button onclick="goToPage('org-people')">People</button>
-      <button onclick="goToPage('org-messages')">Messages</button>
+      <button id="nav-dashboard" onclick="goToPage('main-org')">Dashboard</button>
+      <button id="nav-services" onclick="goToPage('org-services')">Services</button>
+      <button id="nav-teams" onclick="goToPage('org-teams')">Teams</button>
+      <button id="nav-people" onclick="goToPage('org-people')">People</button>
+      <button id="nav-messages" onclick="goToPage('org-messages')">Messages</button>
       <button class="back-btn" onclick="window.location.href='/user-organizations'">My organizations</button>
       <div class="user-icon" id="user-icon-container" style="position: relative;">
         <svg id="user-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
@@ -119,6 +101,10 @@
     </div>
   </nav>
 
+  <div class="page-actions" id="page-actions" style="padding:20px 40px; display:flex; gap:12px;">
+    <button class="secondary-btn" onclick="showTeamForm()">Create New Team</button>
+  </div>
+
   <div class="main-content" id="main-content">
     <p class="message">Loading teams...</p>
   </div>
@@ -131,6 +117,11 @@
 const userEmail = localStorage.getItem("user_email");
 const firstName = localStorage.getItem("user_first_name") || "";
 const lastName = localStorage.getItem("user_last_name") || "";
+
+function setActiveNav(page) {
+  const btn = document.getElementById('nav-' + page);
+  if (btn) btn.classList.add('active');
+}
 
 const userIcon = document.getElementById('user-icon');
 const userPopup = document.getElementById('user-popup');
@@ -232,7 +223,7 @@ async function initPage() {
 
     if (!isOwner && !isOrgAdmin && !isTeamAdmin) {
       mainContent.innerHTML = `<h2>Access Denied</h2><p>You do not have permission to view this page.</p>`;
-      document.getElementById("floating-add-button").style.display = "none";
+      document.getElementById("page-actions").style.display = "none";
       return;
     }
 
@@ -400,11 +391,8 @@ function addPositionRow() {
   tbody.appendChild(row);
 }
 
+setActiveNav('teams');
 initPage();
 </script>
-<button onclick="showTeamForm()" id="floating-add-button" title="Add Team">
-  +
-</button>
-
 </body>
 </html>

--- a/templates/user-organizations.html
+++ b/templates/user-organizations.html
@@ -21,6 +21,10 @@
 
     .main-content {
       flex: 1;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 20px;
+      padding: 40px;
     }
   </style>
 </head>
@@ -108,13 +112,14 @@
 
     function showStartOrgForm() {
       const mainContent = document.getElementById('main-content');
+      mainContent.style.display = 'block';
       const firstName = localStorage.getItem("user_first_name") || "";
       const lastName = localStorage.getItem("user_last_name") || "";
       const userEmail = localStorage.getItem("user_email");
 
       mainContent.innerHTML = `
         <h2 style="margin-bottom: 20px;">Start a New Organization</h2>
-        <form id="start-org-form" style="max-width: 400px;">
+        <form id="start-org-form" style="max-width: 400px; margin:0 auto;">
           <div style="margin-bottom: 12px;">
             <label for="orgName">Org Name</label><br/>
             <input type="text" id="orgName" required style="width: 100%; padding: 8px;" />


### PR DESCRIPTION
## Summary
- style login page brand and OTP controls
- create shared secondary button style
- display organizations in a grid and center start-org form

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684272319f2c8324a12430f448508037